### PR TITLE
Enable debug console

### DIFF
--- a/Assets/Scripts/Assembly-CSharp/GeneralConfig.cs
+++ b/Assets/Scripts/Assembly-CSharp/GeneralConfig.cs
@@ -310,7 +310,7 @@ public class GeneralConfig
 	{
 		get
 		{
-			return true;
+			return !UnityEngine.Debug.isDebugBuild;
 		}
 	}
 

--- a/Assets/Scripts/Assembly-CSharp/StartScreenImpl.cs
+++ b/Assets/Scripts/Assembly-CSharp/StartScreenImpl.cs
@@ -29,6 +29,8 @@ public class StartScreenImpl : MonoBehaviour, IGluiActionHandler
 
 	private void Awake()
 	{
+		DebugMain instance = SingletonSpawningMonoBehaviour<DebugMain>.Instance;
+		
 		timeScaleBackup = Time.timeScale;
 		if (!Singleton<Profile>.Exists)
 		{


### PR DESCRIPTION
These changes will allow the built-in debug console to be used in (and only in) debug mode.

The console can be accessed by pressing both "[" and "]" together, or by pressing both Alt keys together (this is how it is originally - not my choice).

Before, it was always disabled, so I just messed around a bit to get it active again.